### PR TITLE
Use a patch request ot update a team

### DIFF
--- a/src/AtaneNL/SignRequest/Client.php
+++ b/src/AtaneNL/SignRequest/Client.php
@@ -378,10 +378,10 @@ class Client
             $this->assertGlobalClient();
 
             return $this->decodeJsonResponse(
-                $this->request("teams/${subdomain}", 'post')
+                $this->request("teams/${subdomain}", 'patch')
             );
         } catch (RemoteException $e) {
-            throw new RemoteException("Unable to get team {$subdomain}: {$e->getMessage()}", $e->getCode(), $e);
+            throw new RemoteException("Unable to update team {$subdomain}: {$e->getMessage()}", $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
As mentioned in the SignRequest documentation:
"Use POST to create a Team. To update a field on a Team use PATCH."

Prevents the following error:
Unable to get team <team>:
Client error: `POST https://signrequest.com/api/v1/teams/<team>/` resulted in a `405 Method Not Allowed`